### PR TITLE
Adds percentages as an intensity shift unit

### DIFF
--- a/src/Edit.svelte
+++ b/src/Edit.svelte
@@ -35,13 +35,20 @@
     };
 
     // global shift intensity
-    let shiftIntensityDirection = "higher"
+    let shiftIntensityDirection = "lower"
+    let shiftIntensityUnit = "percent";
     let shiftIntensityVal = 0;
     const shiftIntensity = () => {
       if (parseInt(shiftIntensityVal) < 0)
         shiftIntensityVal *= -1;
-      const intensityDiff = shiftIntensityDirection === "lower" ? shiftIntensityVal * -1 : shiftIntensityVal * 1;
-      intensityShift(aip.entries, intensityDiff);
+
+      const intensityDiff =
+        shiftIntensityDirection === "lower"
+        ? shiftIntensityVal * -1
+        : shiftIntensityVal * 1;
+
+      intensityShift(aip.entries, intensityDiff, shiftIntensityUnit);
+
       aip = aip;
     };
 
@@ -91,11 +98,15 @@
                 <strong>Shift Intensity</strong>
                 <div class="mt-2">
                     <select class="border p-1 rounded" bind:value={shiftIntensityDirection}>
-                        <option value="higher">Higher</option>
                         <option value="lower">Lower</option>
+                        <option value="higher">Higher</option>
                     </select>
                     &nbsp;by&nbsp;
                     <input bind:value={shiftIntensityVal} type="text" class="border w-10 p-1 rounded" />
+                    <select class="border p-1 rounded" bind:value={shiftIntensityUnit}>
+                        <option value="percent">%</option>
+                        <option value="points">points</option>
+                    </select>
                     <button on:click={shiftIntensity} class="cursor-pointer bg-slate-900 text-xs rounded text-white p-1 pl-2 pr-2 ml-4">Apply</button>
                 </div>
             </div>

--- a/src/mutations.js
+++ b/src/mutations.js
@@ -24,19 +24,29 @@ export const timeShift = (colorEntries, minutes) => {
  * Shift all intensity values by the valueDiff amount
  * @param {[color]} colorEntries
  * @param {number} intensityDiff
+ * @param {string} intensityShiftUnit
  * @return {aip}
  */
-export const intensityShift = (colorEntries, intensityDiff) => {
+export const intensityShift = (colorEntries, intensityDiff, intensityShiftUnit) => {
   colorEntries.forEach(entry => {
     entry.values.forEach(val => {
       // skip any 0s because we likely aren't wanting those to move at all
       if (parseInt(val.intensity) === 0)
         return;
-      let newValue = parseInt(val.intensity) + intensityDiff;
-      if (newValue > 1800)
-        newValue = 1800;
-      if (newValue < 0)
-        newValue = 0;
+
+      let newValue = parseInt(val.intensity);
+
+      // if percent, calculate the delta of the % of current intensity
+      let intensityAmount =
+        intensityShiftUnit === 'percent'
+          ? Math.floor(newValue * (intensityDiff * 0.01))
+          : intensityDiff;
+
+      newValue += intensityAmount;
+
+      // 0 < n < 1800
+      newValue = Math.min(Math.max(newValue, 0), 1800);
+
       val.intensity = newValue;
     });
   });


### PR DESCRIPTION
This will allow you to shift the intensity of colours by a percentage instead of simply by points.

I also made "lower" and "percent" as the defaults since I figured that modifying presets to work on a smaller tank would often be the needed case, but I'm not stuck on this and am happy to change.